### PR TITLE
Add basic level generator

### DIFF
--- a/three/GameScene.swift
+++ b/three/GameScene.swift
@@ -16,6 +16,7 @@ class GameScene: SKScene {
     private var lastUpdateTime : TimeInterval = 0
     private var label : SKLabelNode?
     private var spinnyNode : SKShapeNode?
+    private var currentLevel: Level?
     
     override func sceneDidLoad() {
 
@@ -39,6 +40,14 @@ class GameScene: SKScene {
             spinnyNode.run(SKAction.sequence([SKAction.wait(forDuration: 0.5),
                                               SKAction.fadeOut(withDuration: 0.5),
                                               SKAction.removeFromParent()]))
+        }
+
+        // Example level generation for demonstration purposes
+        let generator = LevelGenerator()
+        self.currentLevel = generator.generate(goal: 10)
+        if let level = self.currentLevel {
+            print("Generated level with seed: \(level.seed)")
+            print(level.board.map { $0.map(String.init).joined(separator: " ") }.joined(separator: "\n"))
         }
     }
     

--- a/three/LevelGenerator.swift
+++ b/three/LevelGenerator.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+struct Level {
+    let board: [[Int]]
+    let goal: Int
+    let seed: UInt64
+}
+
+/// Simple level generator for Match-3 math goals.
+/// Generates an 8x8 grid of values 1...5 and ensures there is
+/// at least one horizontal or vertical match of three tiles whose
+/// sum equals the target goal.
+class LevelGenerator {
+    static let size = 8
+    private let maxValue = 5
+
+    /// Generates a level with the provided goal.
+    /// - Parameters:
+    ///   - goal: Target sum for a triple match.
+    ///   - attempts: Number of attempts before giving up.
+    ///   - seed: Optional seed for deterministic generation.
+    /// - Returns: `Level` if solvable, otherwise `nil`.
+    func generate(goal: Int, attempts: Int = 1000, seed: UInt64? = nil) -> Level? {
+        var rng = seed.map { SeededGenerator(seed: $0) } ?? SeededGenerator()
+        for _ in 0..<attempts {
+            let currentSeed = rng.next()
+            let board = randomBoard(generator: &rng)
+            if hasSolution(board: board, goal: goal) {
+                return Level(board: board, goal: goal, seed: currentSeed)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Internal helpers
+
+    private func randomBoard<G: RandomNumberGenerator>(generator: inout G) -> [[Int]] {
+        (0..<Self.size).map { _ in
+            (0..<Self.size).map { _ in
+                Int.random(in: 1...maxValue, using: &generator)
+            }
+        }
+    }
+
+    private func hasSolution(board: [[Int]], goal: Int) -> Bool {
+        let n = Self.size
+        guard board.count == n && board.allSatisfy({ $0.count == n }) else { return false }
+        // Horizontal matches
+        for i in 0..<n {
+            for j in 0..<(n - 2) {
+                let sum = board[i][j] + board[i][j+1] + board[i][j+2]
+                if sum == goal { return true }
+            }
+        }
+        // Vertical matches
+        for i in 0..<(n - 2) {
+            for j in 0..<n {
+                let sum = board[i][j] + board[i+1][j] + board[i+2][j]
+                if sum == goal { return true }
+            }
+        }
+        return false
+    }
+}
+
+/// Deterministic random number generator based on UInt64 seed.
+struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64 = UInt64.random(in: .min...UInt64.max)) {
+        self.state = seed == 0 ? 0xdeadbeef : seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9e3779b97f4a7c15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xbf58476d1ce4e5b9
+        z = (z ^ (z >> 27)) &* 0x94d049bb133111eb
+        return z ^ (z >> 31)
+    }
+}

--- a/threeTests/threeTests.swift
+++ b/threeTests/threeTests.swift
@@ -10,8 +10,10 @@ import Testing
 
 struct threeTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func levelGeneratorProducesSolvableLevel() throws {
+        let generator = LevelGenerator()
+        let level = generator.generate(goal: 10)
+        #expect(level != nil)
     }
 
 }


### PR DESCRIPTION
## Summary
- implement `LevelGenerator` to create math-based Match‑3 levels
- demonstrate level generation in `GameScene`
- add a unit test for level creation

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68888709b68c8326a5091091b0eeae92